### PR TITLE
Update interfaces.py

### DIFF
--- a/starry_process/interfaces.py
+++ b/starry_process/interfaces.py
@@ -135,7 +135,7 @@ class MCMCInterface:
                             "Unable to initialize walkers at a point with finite `logp`. "
                             "Try reducing `var` or running `optimize()`."
                         )
-                    p0[k] = p.random.multivariate_normal(mean, cov)
+                    p0[k] = np.random.multivariate_normal(mean, cov)
 
         return p0
 


### PR DESCRIPTION
there was an incorrect call to np.random.multivariate_normal() that caused errors when calling mci.get_initial_state